### PR TITLE
Make textarea elements not quite so wide

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@ body {
 }
 
 textarea {
-  width: 80em;
+  width: 48em;
   height: 95%;
   background: #ECF0F1;
   border: 1px solid #BDC3C7;


### PR DESCRIPTION
For some reason, `em` in CSS doesn't actually correspond to the width of an M in this context.
